### PR TITLE
joystick 2 disability fixed - Issue 54

### DIFF
--- a/CORE/vhdl/mega65.vhd
+++ b/CORE/vhdl/mega65.vhd
@@ -270,7 +270,9 @@ begin
    cart_ctrl_oe_o       <= '0';
    cart_addr_oe_o       <= '0';
    cart_data_oe_o       <= '0';
-   cart_en_o            <= '0'; -- Disable port
+
+   -- Due to a bug in the R5/R6 boards, the cartridge port needs to be enabled for joystick port 2 to work 
+   cart_en_o            <= '1';
 
    cart_reset_oe_o      <= '0';
    cart_game_oe_o       <= '0';


### PR DESCRIPTION
Due to a bug in the R5/R6 boards, the cartridge port needs to be enabled for joystick port 2 to work.

original issue: https://github.com/sy2002/MiSTer2MEGA65/issues/54
