### PR TITLE
PATCH M2M for bug 52.

### DIFF
--- a/M2M/rom/shell.asm
+++ b/M2M/rom/shell.asm
@@ -1061,6 +1061,12 @@ _HDR_SEND_DONE  MOVE    R11, R8                 ; virtual drive ID
                 XOR     R10, R10
                 RSUB    VD_DRV_WRITE, 1
 
+                ; unassert write enable.
+                ; we don't want it active when reading from the disk later!
+                MOVE    VD_B_WREN, R8           ; unassert write enable
+                XOR     R9, R9                  ; make zero
+                RSUB    VD_CAD_WRITE, 1
+
                 SYSCALL(leave, 1)
                 RET
 


### PR DESCRIPTION
https://github.com/sy2002/MiSTer2MEGA65/issues/52

What I see is that the drive wants to save its data, so the qnice code iterates over the track buffer to fetch all the data. However when it is finished, and the address is pointing at the last byte of the track buffer, it strobes the ACK signal. And since the write enable is still on, this actually activates a write into the track buffer... corrupting it.

Fix: explicitly reset write enable VD_B_WREN (sd_buff_wr in the drive). Leave the XOR bug as it is, so that write enable remains on all the time during writing into the disk's buffer.