### PR TITLE
Avm increase fixes

### DIFF
--- a/M2M/vhdl/memory/avm_increase.vhd
+++ b/M2M/vhdl/memory/avm_increase.vhd
@@ -56,7 +56,13 @@ architecture synthesis of avm_increase is
 
 begin
 
-  s_avm_waitrequest_o   <= '0' when (state = IDLE_ST or state = WRITING_ST) and
+  -- A read presented in WRITING_ST is NOT accepted (see the abort-drain in
+  -- the FSM): without this term it was silently dropped — no conformant
+  -- master interleaves a read into its own write burst, but an aborted
+  -- upstream (reset race, decouple chop) can leave this converter holding
+  -- burst debt that the next master's read then runs into.
+  s_avm_waitrequest_o   <= '1' when state = WRITING_ST and s_avm_read_i = '1' else
+                           '0' when (state = IDLE_ST or state = WRITING_ST) and
                            (m_avm_write_o = '0' or m_avm_waitrequest_i = '0') else
                            '1';
 
@@ -142,6 +148,26 @@ begin
                 m_avm_byteenable_o(G_SLAVE_DATA_SIZE / 8 * (i + 1) - 1 downto G_SLAVE_DATA_SIZE / 8 * i) <= s_avm_byteenable_i;
               end if;
             end loop;
+
+            if s_burstcount = 1 then
+              m_avm_write_o <= '1';
+              state         <= IDLE_ST;
+            end if;
+          elsif s_avm_read_i = '1' and s_burstcount > 0 and
+                (m_avm_write_o = '0' or m_avm_waitrequest_i = '0') then
+            -- Abort-drain: the writer of this burst died (it will never
+            -- deliver the remaining beats), so self-complete the announced
+            -- master burst with dummy beats — byteenable lanes stay 0, so
+            -- memory content is untouched.  The read is held off by
+            -- waitrequest above and gets accepted normally in IDLE_ST.
+            -- A plain read-stall would deadlock instead: nobody else
+            -- generates the drain beats.
+            s_burstcount <= s_burstcount - 1;
+            offset       <= offset + 1;
+
+            if offset = C_RATIO - 1 then
+              m_avm_write_o <= '1';
+            end if;
 
             if s_burstcount = 1 then
               m_avm_write_o <= '1';

--- a/M2M/vhdl/memory/avm_increase.vhd
+++ b/M2M/vhdl/memory/avm_increase.vhd
@@ -161,11 +161,17 @@ begin
           end if;
 
         when RESPONSE_ST =>
-          if s_burstcount > 1 then
-            s_burstcount <= s_burstcount - 1;
-            offset       <= offset + 1;
-          else
-            state <= IDLE_ST;
+          -- Only advance when the word for the current beat is present in the
+          -- FIFO: with a master that delivers read words with gaps (e.g. a
+          -- DDR3 controller), unconditional streaming would emit stale data
+          -- from the previous word.
+          if m_avm_readdatavalid = '1' then
+            if s_burstcount > 1 then
+              s_burstcount <= s_burstcount - 1;
+              offset       <= offset + 1;
+            else
+              state <= IDLE_ST;
+            end if;
           end if;
 
         when others =>
@@ -182,8 +188,7 @@ begin
   end process fsm_proc;
 
   s_avm_readdata_o      <= m_avm_readdata(G_SLAVE_DATA_SIZE * (to_integer(offset) + 1) - 1 downto G_SLAVE_DATA_SIZE * to_integer(offset));
-  s_avm_readdatavalid_o <= m_avm_readdatavalid when state = READING_ST else
-                           '1' when state = RESPONSE_ST else
+  s_avm_readdatavalid_o <= m_avm_readdatavalid when state = READING_ST or state = RESPONSE_ST else
                            '0';
 
   m_avm_ready           <= '1' when offset = C_RATIO - 1 or state = IDLE_ST else


### PR DESCRIPTION
These two commits aim to fix latent bugs in M2M/vhdl/memory/avm_increase.vhd. The component currently isn't instantiated by any MEGA65 build, but it's latently broken for any future consumer. We hit both bugs on real hardware on a board port that drives a 128-bit DDR3 controller through it: gapped read responses emitted stale data (visible as corrupt vertical bands from framebuffer reads), and a write burst orphaned by a reset race permanently wedged the converter. Both fixes are validated by a byte-accurate testbench with random stalls/latency and by hardware use since.